### PR TITLE
Adapt to bevy latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["game-engines", "game-development"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy = { version = "0.4", default-features = false, features = ["render"] }
+bevy = { git = "https://github.com/bevyengine/bevy/" }


### PR DESCRIPTION
Make the flycam plugin compliable and usable with the latest bevy branch. Remove use of deprecated functions. 