### PR TITLE
Use `normalize_or_zero` to avoid a `glam_assert` from firing.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,11 +78,9 @@ fn player_move(
             }
         }
 
-        velocity = velocity.normalize();
+        velocity = velocity.normalize_or_zero();
 
-        if !velocity.is_nan() {
-            transform.translation += velocity * time.delta_seconds() * settings.speed
-        }
+        transform.translation += velocity * time.delta_seconds() * settings.speed
     }
 }
 


### PR DESCRIPTION
There is an optional feature in glam which asserts on invalid input. This code was triggering the assert when attempting to normalize a zero length vector. This PR uses a newish glam method that returns a zero vector in the instance where the input vector could not be normalized and avoids the assert.