### PR TITLE
Migrate to `bevy` v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "bevy_flycam"
 readme = "README.md"
 repository = "https://github.com/sburris0/bevy_flycam/"
 resolver = "2"
-version = "0.5.1"
+version = "0.6.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
@@ -21,4 +21,3 @@ bevy = {version = "0.6", default-features = false, features = ["render", "bevy_r
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 bevy = {version = "0.6", default-features = false, features = ["x11", "wayland"]}
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,3 @@ bevy = {version = "0.6", default-features = false, features = ["render", "bevy_r
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 bevy = {version = "0.6", default-features = false, features = ["x11", "wayland"]}
 
-[[example]]
-name = "basic"
-path = "examples/basic.rs"
-
-[[example]]
-name = "scroll"
-path = "examples/scroll.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,18 @@ license = "ISC"
 name = "bevy_flycam"
 readme = "README.md"
 repository = "https://github.com/sburris0/bevy_flycam/"
+resolver = "2"
 version = "0.5.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy = {version = "0.5", default-features = false, features = ["render"]}
+bevy = {version = "0.6", default-features = false, features = ["render"]}
 
 [dev-dependencies]
-bevy = {version = "0.5", default-features = false, features = ["render", "bevy_winit", "bevy_wgpu"]}
+bevy = {version = "0.6", default-features = false, features = ["render", "bevy_render", "bevy_winit"]}
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-bevy = {version = "0.5", default-features = false, features = ["x11", "wayland"]}
+bevy = {version = "0.6", default-features = false, features = ["x11", "wayland"]}
 
 [[example]]
 name = "basic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,30 @@
 [package]
-name = "bevy_flycam"
-version = "0.5.1"
 authors = ["Spencer Burris <sburris@posteo.net>"]
-edition = "2018"
-license = "ISC"
-description = "Basic first-person fly camera for the Bevy game engine"
-homepage = "https://github.com/sburris0/bevy_flycam/"
-repository = "https://github.com/sburris0/bevy_flycam/"
-readme = "README.md"
-keywords = ["gamedev", "bevy", "3d", "camera", ]
 categories = ["game-engines", "game-development"]
-
+description = "Basic first-person fly camera for the Bevy game engine"
+edition = "2018"
+homepage = "https://github.com/sburris0/bevy_flycam/"
+keywords = ["gamedev", "bevy", "3d", "camera"]
+license = "ISC"
+name = "bevy_flycam"
+readme = "README.md"
+repository = "https://github.com/sburris0/bevy_flycam/"
+version = "0.5.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy = { version = "0.5", default-features = false, features = ["render"] }
+bevy = {version = "0.5", default-features = false, features = ["render"]}
 
 [dev-dependencies]
-bevy = { version = "0.5", default-features = false, features = ["render", "bevy_winit", "bevy_wgpu" ] }
+bevy = {version = "0.5", default-features = false, features = ["render", "bevy_winit", "bevy_wgpu"]}
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-bevy = { version = "0.5", default-features = false, features = [ "x11", "wayland" ] }
+bevy = {version = "0.5", default-features = false, features = ["x11", "wayland"]}
+
+[[example]]
+name = "basic"
+path = "examples/basic.rs"
+
+[[example]]
+name = "scroll"
+path = "examples/scroll.rs"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -9,7 +9,7 @@ use bevy_flycam::PlayerPlugin;
 //https://github.com/bevyengine/bevy/blob/latest/examples/3d/3d_scene.rs
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_plugin(PlayerPlugin)
@@ -41,7 +41,7 @@ fn setup(
         ..Default::default()
     });
     // light
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..Default::default()
     });

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -17,7 +17,7 @@ enum ScrollType {
 }
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         //NoCameraPlayerPlugin as we provide the camera
@@ -53,7 +53,7 @@ fn setup(
         ..Default::default()
     });
     // light
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..Default::default()
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ impl Default for MovementSettings {
 }
 
 /// Used in queries when you want flycams and not other cameras
+#[derive(Component)]
+#[component(storage = "SparseSet")]
 pub struct FlyCam;
 
 /// Grabs/ungrabs mouse cursor
@@ -122,26 +124,26 @@ fn cursor_grab(keys: Res<Input<KeyCode>>, mut windows: ResMut<Windows>) {
 /// Contains everything needed to add first-person fly camera behavior to your game
 pub struct PlayerPlugin;
 impl Plugin for PlayerPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(&self, app: &mut App) {
         app.init_resource::<InputState>()
             .init_resource::<MovementSettings>()
-            .add_startup_system(setup_player.system())
-            .add_startup_system(initial_grab_cursor.system())
-            .add_system(player_move.system())
-            .add_system(player_look.system())
-            .add_system(cursor_grab.system());
+            .add_startup_system(setup_player)
+            .add_startup_system(initial_grab_cursor)
+            .add_system(player_move)
+            .add_system(player_look)
+            .add_system(cursor_grab);
     }
 }
 
 /// Same as `PlayerPlugin` but does not spawn a camera
 pub struct NoCameraPlayerPlugin;
 impl Plugin for NoCameraPlayerPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(&self, app: &mut App) {
         app.init_resource::<InputState>()
             .init_resource::<MovementSettings>()
-            .add_startup_system(initial_grab_cursor.system())
-            .add_system(player_move.system())
-            .add_system(player_look.system())
-            .add_system(cursor_grab.system());
+            .add_startup_system(initial_grab_cursor)
+            .add_system(player_move)
+            .add_system(player_look)
+            .add_system(cursor_grab);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@ impl Default for MovementSettings {
 
 /// Used in queries when you want flycams and not other cameras
 #[derive(Component)]
-#[component(storage = "SparseSet")]
 pub struct FlyCam;
 
 /// Grabs/ungrabs mouse cursor


### PR DESCRIPTION
This PR mostly deals with breaking changes from migrating to `bevy` version 0.6, as per the [Bevy migration guide](https://bevyengine.org/learn/book/migration-guides/0.5-0.6/).

Some callouts:

* Used `StorageType::SparseSet` for `FlyCam`, since I expect it to only exist approximately for one entity.
* Added `[[example]]` sections to the repository config.