### PR TITLE
Reduce Bevy dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,7 @@ resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy = {version = "0.6", default-features = false, features = ["render"]}
+bevy = {version = "0.6", default-features = false, features = ["bevy_render"]}
 
 [dev-dependencies]
-bevy = {version = "0.6", default-features = false, features = ["bevy_winit"]}
-
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-bevy = {version = "0.6", default-features = false, features = ["x11", "wayland"]}
+bevy = {version = "0.6", default-features = false, features = ["x11", "wayland", "bevy_pbr", "bevy_core_pipeline"]}


### PR DESCRIPTION
Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202

`wayland` and `x11` features doesn't affect on anything on platforms other then Linux. `x11` feature is even enabled by default in Bevy.